### PR TITLE
Only specify libcxx for google benchamrk on Android

### DIFF
--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -2,7 +2,9 @@
 
 macro(configure_benchmark)
     # option(BENCHMARK_DOWNLOAD_DEPENDENCIES "" ON)
-    option(BENCHMARK_USE_LIBCXX "" ON)
+    if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+        option(BENCHMARK_USE_LIBCXX "" ON)
+    endif()
     option(BENCHMARK_ENABLE_TESTING "" OFF)
     set(HAVE_STD_REGEX 0)
     set(HAVE_POSIX_REGEX 0)


### PR DESCRIPTION
dabnn x86 build breaks on clang 8 if libcxx is specified